### PR TITLE
Changes need for use with MathJax3

### DIFF
--- a/scripts/ts/abstract_item.ts
+++ b/scripts/ts/abstract_item.ts
@@ -263,7 +263,7 @@ namespace ContextMenu {
       let active = MenuUtil.getActiveElement(this);
       for (let func of this.callbacks) {
         try {
-          func(event);
+          func(this);
         } catch (e) {
           MenuUtil.error(e, 'Callback for menu entry ' + this.getId() +
                          ' failed.');

--- a/scripts/ts/context_menu.ts
+++ b/scripts/ts/context_menu.ts
@@ -311,3 +311,5 @@ namespace ContextMenu {
   }
 
 }
+
+(window as any).ContextMenu = ContextMenu;

--- a/scripts/ts/menu_store.ts
+++ b/scripts/ts/menu_store.ts
@@ -355,6 +355,8 @@ namespace ContextMenu {
     private keydown(event: KeyboardEvent) {
       if (event.keyCode === KEY.SPACE) {
         this.menu.post(event);
+        event.preventDefault();
+        event.stopImmediatePropagation();
       }
     }
 


### PR DESCRIPTION
These are a couple of updates needed for use with MathJax v3.

1.  In `abstract_item.ts` there is no global `event` (in some browsers), and it is useful to have the actual variable item that is being changed, so I pass that instead.

2.  In `context_menu.ts`, if you webpack the context menu into a larger package, `ContextMenu` won't be global, so I explicitly set the global value.

3.  In `menu_store.ts`, we need to prevent the default action and stop immediate propagation, since the context menu and the explorer are both on the same HTML element, and they both want to respond to shift-space keypresses, but we only want one to do so.