### PR TITLE
Updates for MathJax3

### DIFF
--- a/scripts/ts/context_menu.ts
+++ b/scripts/ts/context_menu.ts
@@ -77,7 +77,7 @@ namespace ContextMenu {
       }
       // The variable id is currently ignored!
       let {pool: pool, items: items, id: id} = menu;
-      let ctxtMenu = new ContextMenu();
+      let ctxtMenu = new this();
       // TODO: Try and catch with error
       pool.forEach(ctxtMenu.parseVariable.bind(ctxtMenu));
       ctxtMenu.parseItems(items);
@@ -312,4 +312,10 @@ namespace ContextMenu {
 
 }
 
-(window as any).ContextMenu = ContextMenu;
+declare const global: any;
+
+if (typeof window !== 'undefined') {
+    (window as any).ContextMenu = ContextMenu;
+} else if (typeof global !== 'undefined') {
+    (global as any).ContextMenu = ContextMenu;
+}

--- a/scripts/ts/context_menu.ts
+++ b/scripts/ts/context_menu.ts
@@ -27,7 +27,6 @@
 /// <reference path="item.ts" />
 /// <reference path="menu_store.ts" />
 
-
 namespace ContextMenu {
 
   export class ContextMenu extends AbstractMenu {
@@ -312,10 +311,6 @@ namespace ContextMenu {
 
 }
 
-declare const global: any;
-
 if (typeof window !== 'undefined') {
     (window as any).ContextMenu = ContextMenu;
-} else if (typeof global !== 'undefined') {
-    (global as any).ContextMenu = ContextMenu;
 }


### PR DESCRIPTION
This PR does two things:

1.. Check that `window` exists before using it, and use `global` if not.  This allows the code to be loaded on node, though it really can't be used there.  This is needed by MathJax 3 in order to allow the combined component files to be loaded in node.

2. Use `new this()` to create the menu so that subclasses can be created properly without having to redefine the `create()` static method.