### PR TITLE
Move press() call from mousedown to mouseup.

### DIFF
--- a/ts/item_command.ts
+++ b/ts/item_command.ts
@@ -10,7 +10,7 @@
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either expressor implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */
@@ -64,6 +64,24 @@ export class Command extends AbstractItem {
     id?: string
   ) {
     super(menu, 'command', content, id);
+  }
+
+  /**
+   * @param {MouseEvent} event   The mousedown event
+   */
+  public mousedown(event: MouseEvent) {
+    this.stop(event);
+  }
+
+  /**
+   * Do the press on mouseup so menu gets the mouse up rather than a dialog box
+   * after the menu closes.
+   *
+   * @param {MouseEvent} event   The mouseup event
+   */
+  public mouseup(event: MouseEvent) {
+    this.press();
+    this.stop(event);
   }
 
   /**

--- a/ts/item_command.ts
+++ b/ts/item_command.ts
@@ -10,7 +10,7 @@
  *
  *  Unless required by applicable law or agreed to in writing, software
  *  distributed under the License is distributed on an "AS IS" BASIS,
- *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either expressor implied.
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  *  See the License for the specific language governing permissions and
  *  limitations under the License.
  */

--- a/ts/item_command.ts
+++ b/ts/item_command.ts
@@ -74,7 +74,7 @@ export class Command extends AbstractItem {
   }
 
   /**
-   * Do the press on mouseup so menu gets the mouse up rather than a dialog box
+   * Perform press on mouseup so menu gets the mouse up rather than a dialog box
    * after the menu closes.
    *
    * @param {MouseEvent} event   The mouseup event


### PR DESCRIPTION
This PR changes command-based menu items to process the `press()` method on mouse up rather than mouse down, so that the mouseup event ge4ts processed by the menu rather than being passed on to whatever is behind the menu.  That is important, for example, when a dialog is opened, so that the mouse doesn't cancel the dialog.  

This also means you can click on a menu item and then move off the menu item to prevent its action from being taken, as with most os system menus.