### PR TITLE
Update sliders to close menu after changing value

### DIFF
--- a/ts/item_slider.ts
+++ b/ts/item_slider.ts
@@ -163,7 +163,8 @@ export class Slider extends AbstractVariableItem<string> {
   /**
    * @override
    */
-  public mouseup(_event: MouseEvent) {
+  public mouseup(event: MouseEvent) {
+    MenuUtil.close(this);
     // Needed for Firefox
     event.stopPropagation();
   }


### PR DESCRIPTION
This PR causes the menu to close when a slider has been changed.  That makes it work like all the other items when selected. Otherwise the user has to figure out how to close the menu after making a slider change.

It also fixes the reference to `event` from being a global reference (deprecated) to being the event passed to it.